### PR TITLE
Update cct_module sprint reference in overrides-cp.yaml file after sp…

### DIFF
--- a/tomcat9/overrides-cp.yaml
+++ b/tomcat9/overrides-cp.yaml
@@ -2,7 +2,7 @@ modules:
       repositories:
           - git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-25
+                  ref: sprint-28
 osbs:
       repository:
             name: containers/jboss-webserver-5


### PR DESCRIPTION
…rint 28 release(version 1.2)

Signed-off-by: Sokratis Zappis <szappis@redhat.com>