### PR TITLE
Updating openj9 templates naming scheme and readiness probe for 5.4

### DIFF
--- a/templates/jws54-openj9-tomcat9-ubi8-basic-s2i.json
+++ b/templates/jws54-openj9-tomcat9-ubi8-basic-s2i.json
@@ -7,17 +7,17 @@
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "tomcat,tomcat9,java,jboss",
             "version": "1.0",
-            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 (no https)",
+            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (no https)",
             "description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, and an application deployment configuration.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "jws54-openj9-tomcat9-rhel8-basic-s2i"
+        "name": "jws54-openj9-tomcat9-ubi8-basic-s2i"
     },
     "labels": {
-        "template": "jws54-openj9-tomcat9-rhel8-basic-s2i",
-        "jws54openj9el8": "1.0"
+        "template": "jws54-openj9-tomcat9-ubi8-basic-s2i",
+        "jws54openj9ubi8": "1.0"
     },
     "message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
     "parameters": [
@@ -199,7 +199,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-webserver54-openj9-tomcat9-rhel8-openshift:1.0"
+                            "name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8:1.0"
                         }
                     }
                 },
@@ -287,7 +287,7 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'"
+                                            "curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
                                         ]
                                     }
                                 },

--- a/templates/jws54-openj9-tomcat9-ubi8-https-s2i.json
+++ b/templates/jws54-openj9-tomcat9-ubi8-https-s2i.json
@@ -7,18 +7,18 @@
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "tomcat,tomcat9,java,jboss,hidden",
             "version": "1.0",
-            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 (with https)",
+            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (with https)",
             "description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, application deployment configuration, and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
             "template.openshift.io/support-url": "https://access.redhat.com"
 
         },
-        "name": "jws54-openj9-tomcat9-rhel8-https-s2i"
+        "name": "jws54-openj9-tomcat9-ubi8-https-s2i"
     },
     "labels": {
-        "template": "jws54-openj9-tomcat9-rhel8-https-s2i",
-        "jws54openj9el8": "1.0"
+        "template": "jws54-openj9-tomcat9-ubi8-https-s2i",
+        "jws54openj9ubi8": "1.0"
     },
     "message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
     "parameters": [
@@ -282,7 +282,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-webserver54-openj9-tomcat9-rhel8-openshift:1.0"
+                            "name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8:1.0"
                         }
                     }
                 },
@@ -370,7 +370,7 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer&att=stateName' |grep -iq 'stateName *= *STARTED'"
+                                            "curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
                                         ]
                                     }
                                 },

--- a/templates/jws54-openj9-tomcat9-ubi8-image-stream.json
+++ b/templates/jws54-openj9-tomcat9-ubi8-image-stream.json
@@ -2,9 +2,9 @@
     "kind": "List",
     "apiVersion": "v1",
     "metadata": {
-        "name": "webserver54-openj9-tomcat9-rhel8-image-stream",
+        "name": "webserver54-openj9-tomcat9-ubi8-image-stream",
         "annotations": {
-            "description": "ImageStream definition for Red Hat JBoss Web Server 5.4 Apache Tomcat 9 with openj9.",
+            "description": "ImageStream definition for Red Hat JBoss Web Server 5.4 Apache Tomcat 9 with OpenJ9 JDK11 on UBI8.",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -13,7 +13,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-webserver54-openj9-tomcat9-rhel8-openshift",
+                "name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8",
                 "annotations": {
                     "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,21 +21,21 @@
                 }
             },
             "labels": {
-                "jws54openj9el8": "1.0"
+                "jws54openj9ubi8": "1.0"
             },
             "spec": {
                 "tags": [
                     {
                         "name": "latest",
                         "annotations": {
-                            "description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 S2I images.",
+                            "description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
                             "iconClass": "icon-rh-tomcat",
                             "tags": "builder,tomcat,tomcat9,java,jboss,hidden",
                             "supports": "tomcat9:5.4,tomcat:9,java:11",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11"
+                            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8"
                         },
 			"referencePolicy": {
                             "type": "Local"
@@ -51,14 +51,14 @@
                     {
                         "name": "1.0",
                         "annotations": {
-                            "description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 S2I images.",
+                            "description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
                             "iconClass": "icon-rh-tomcat",
                             "tags": "builder,tomcat,tomcat9,java,jboss,hidden",
                             "supports": "tomcat9:5.4,tomcat:9,java:11",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
                             "sampleContextDir": "tomcat-websocket-chat",
                             "version": "1.0",
-                            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11"
+                            "openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8"
                         },
 			"referencePolicy": {
                             "type": "Local"


### PR DESCRIPTION
Updating templates to UBI8, adjusted ImageStream naming and updated the readiness probe. Changes to match Sokratis' forked repo.