### PR TITLE
Adding back 'os-jws-rm-root' module

### DIFF
--- a/tomcat9/image.yaml
+++ b/tomcat9/image.yaml
@@ -130,6 +130,8 @@ modules:
             version: "3.0"
           - name: jws-secure-mgmt-console
             version: "1.0"
+          - name: os-jws-rm-root
+            version: "3.0"
           - name: os-jws-rm-defaults
             version: "3.0"
           - name: os-jws-chmod


### PR DESCRIPTION
QE identified test failures and adding back the 'os-jws-rm-root' module resolved the issue.