### PR TITLE
Fix JVM module version for JDK8 and JDK11 after JDK17 update

### DIFF
--- a/tomcat9/image.yaml
+++ b/tomcat9/image.yaml
@@ -116,6 +116,7 @@ modules:
           - name: os-jws-jolokia
             version: "3.0"
           - name: jboss.container.java.jvm.bash
+            version: "1.0"
           - name: os-jws-launch
             version: "3.0"
           - name: os-jws-https


### PR DESCRIPTION
Fix JVM module version for JDK8 and JDK11 after JDK17 update