### PR TITLE
Prometheus module order rearranging

### DIFF
--- a/tomcat9/image.yaml
+++ b/tomcat9/image.yaml
@@ -131,8 +131,6 @@ modules:
           - name: jboss.container.util.logging.bash
           - name: os-eap-python
             version: "3.6"
-          - name: os-jws-prometheus
-            version: "3.0"
           - name: jws5-logging
             version: "1.0"
 

--- a/tomcat9/jdk11-overrides.yaml
+++ b/tomcat9/jdk11-overrides.yaml
@@ -24,6 +24,8 @@ modules:
           - path: custom-modules
       install:
           - name: jboss.container.java.singleton-jdk
+          - name: os-jws-prometheus
+            version: "3.0"
 
 packages:
       content_sets_file: content_sets_rhel8_jdk11.yml

--- a/tomcat9/jdk17-overrides.yaml
+++ b/tomcat9/jdk17-overrides.yaml
@@ -24,6 +24,8 @@ modules:
           - path: custom-modules
       install:
           - name: jboss.container.java.singleton-jdk
+          - name: os-jws-prometheus
+            version: "3.0"
           - name: jboss.container.java.jvm.bash
             version: "2.0"
 

--- a/tomcat9/jdk8-overrides.yaml
+++ b/tomcat9/jdk8-overrides.yaml
@@ -13,6 +13,8 @@ modules:
           - path: custom-modules
       install:
           - name: java-alternatives
+          - name: os-jws-prometheus
+            version: "3.0"
 
 osbs:
       repository:


### PR DESCRIPTION
Make sure that the prometheus module is always run **after** the singleton-jdk module, to avoid causing issues on JDK11 image, where the java-11 package was being removed due to java-1.8.0-openjdk still being present when the module was run.